### PR TITLE
fix: add .js extension to rule imports for ESM compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,12 +3,12 @@
  * @author eslint-plugin-code-complete
  */
 
-import noBooleanParams from './rules/no-boolean-params';
-import noMagicNumbersExceptZeroOne from './rules/no-magic-numbers-except-zero-one';
-import enforceMeaningfulNames from './rules/enforce-meaningful-names';
-import noLateArgumentUsage from './rules/no-late-argument-usage';
-import noLateVariableUsage from './rules/no-late-variable-usage';
-import lowFunctionCohesion from './rules/low-function-cohesion';
+import noBooleanParams from './rules/no-boolean-params.js';
+import noMagicNumbersExceptZeroOne from './rules/no-magic-numbers-except-zero-one.js';
+import enforceMeaningfulNames from './rules/enforce-meaningful-names.js';
+import noLateArgumentUsage from './rules/no-late-argument-usage.js';
+import noLateVariableUsage from './rules/no-late-variable-usage.js';
+import lowFunctionCohesion from './rules/low-function-cohesion.js';
 
 export default {
   rules: {


### PR DESCRIPTION
## Description

This PR updates all rule imports in the plugin entry point to include the `.js` extension, ensuring compatibility with ESLint 9+ and ESM config files. Without this change, users encounter "Cannot find module" errors when using the plugin with ESM.

Fixes #1 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Ran `npm test` to ensure all existing tests pass
- [x] Verified plugin loads correctly in a test project using ESLint 9+ and ESM config (`eslint.config.mjs`)
- [x] Confirmed that rules are available and no "Cannot find module" errors occur

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 