### PR TITLE
feat: add max-function-length and prefer-early-return rules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,9 @@ export default {
     'max-nesting-depth': rules.maxNestingDepth,
     'high-parameter-coupling': rules.highParameterCoupling,
     'high-import-coupling': rules.highImportCoupling,
-    'high-fan-out': rules.highFanOut
+    'high-fan-out': rules.highFanOut,
+    'max-function-length': rules.maxFunctionLength,
+    'prefer-early-return': rules.preferEarlyReturn
   }
 };
 

--- a/rules/index.ts
+++ b/rules/index.ts
@@ -9,4 +9,6 @@ export { default as noComplexConditionals } from './no-complex-conditionals';
 export { default as maxNestingDepth } from './max-nesting-depth';
 export { default as highParameterCoupling } from './high-parameter-coupling';
 export { default as highImportCoupling } from './high-import-coupling';
-export { default as highFanOut } from './high-fan-out'; 
+export { default as highFanOut } from './high-fan-out';
+export { default as maxFunctionLength } from './max-function-length';
+export { default as preferEarlyReturn } from './prefer-early-return';

--- a/rules/max-function-length.ts
+++ b/rules/max-function-length.ts
@@ -1,0 +1,99 @@
+import { Rule } from 'eslint';
+import { MaxFunctionLengthOptions } from '../types/rule-options.js';
+import { createRuleMeta, RULE_CATEGORIES } from '../utils/rule-meta.js';
+
+const rule: Rule.RuleModule = {
+  meta: createRuleMeta('max-function-length', {
+    description: 'Enforce a maximum number of lines per function to improve readability and cohesion',
+    category: RULE_CATEGORIES.BEST_PRACTICES,
+    recommended: true,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxLines: {
+            type: 'number',
+            minimum: 1,
+            default: 30
+          },
+          skipBlankLines: {
+            type: 'boolean',
+            default: true
+          },
+          skipComments: {
+            type: 'boolean',
+            default: true
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      maxFunctionLength: `Function '{{name}}' has {{lines}} lines, exceeding the maximum of {{maxLines}}.
+
+Long functions are hard to understand and test. Consider:
+1. Extracting cohesive blocks into well-named helper functions
+2. Breaking complex conditionals into named predicate functions
+3. Using the single-responsibility principle — one function, one job`
+    }
+  }),
+
+  create(context: Rule.RuleContext): Rule.RuleListener {
+    const options = (context.options[0] || {}) as MaxFunctionLengthOptions;
+    const maxLines = options.maxLines !== undefined ? options.maxLines : 30;
+    const skipBlankLines = options.skipBlankLines !== undefined ? options.skipBlankLines : true;
+    const skipComments = options.skipComments !== undefined ? options.skipComments : true;
+
+    const sourceCode = context.getSourceCode();
+
+    function countLines(node: any): number {
+      const body = node.body;
+      if (!body || body.type !== 'BlockStatement' || !body.loc) return 0;
+
+      // Count lines inside the block, excluding the opening { and closing } lines
+      const start = body.loc.start.line + 1;
+      const end = body.loc.end.line - 1;
+      if (end < start) return 0;
+
+      const lines = sourceCode.lines.slice(start - 1, end);
+      return lines.filter(line => {
+        const trimmed = line.trim();
+        if (skipBlankLines && trimmed === '') return false;
+        if (skipComments && (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*'))) return false;
+        return true;
+      }).length;
+    }
+
+    function getFunctionName(node: any): string {
+      if (node.id?.name) return node.id.name;
+      if (node.parent?.type === 'VariableDeclarator' && node.parent.id?.name) return node.parent.id.name;
+      if (node.parent?.type === 'Property' && node.parent.key?.name) return node.parent.key.name;
+      if (node.parent?.type === 'MethodDefinition' && node.parent.key?.name) return node.parent.key.name;
+      if (node.parent?.type === 'AssignmentExpression' && node.parent.left?.name) return node.parent.left.name;
+      return '<anonymous>';
+    }
+
+    function checkFunction(node: any): void {
+      const lines = countLines(node);
+      if (lines > maxLines) {
+        context.report({
+          node,
+          messageId: 'maxFunctionLength',
+          data: {
+            name: getFunctionName(node),
+            lines: lines.toString(),
+            maxLines: maxLines.toString()
+          }
+        });
+      }
+    }
+
+    return {
+      FunctionDeclaration: checkFunction,
+      FunctionExpression: checkFunction,
+      ArrowFunctionExpression: checkFunction
+    };
+  }
+};
+
+export default rule;

--- a/rules/prefer-early-return.ts
+++ b/rules/prefer-early-return.ts
@@ -1,0 +1,98 @@
+import { Rule } from 'eslint';
+import { PreferEarlyReturnOptions } from '../types/rule-options.js';
+import { createRuleMeta, RULE_CATEGORIES } from '../utils/rule-meta.js';
+
+const rule: Rule.RuleModule = {
+  meta: createRuleMeta('prefer-early-return', {
+    description: 'Prefer early returns over wrapping the entire function body in a conditional',
+    category: RULE_CATEGORIES.BEST_PRACTICES,
+    recommended: true,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxLines: {
+            type: 'number',
+            minimum: 1,
+            default: 3,
+            description: 'Minimum lines in the if-body to trigger the rule'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      preferEarlyReturn: `Prefer an early return over wrapping the function body in an 'if' statement.
+
+Instead of:
+  function foo(x) {
+    if (condition) {
+      // all the work
+    }
+  }
+
+Use:
+  function foo(x) {
+    if (!condition) return;
+    // all the work
+  }
+
+This reduces nesting and makes the happy path easier to follow.`
+    }
+  }),
+
+  create(context: Rule.RuleContext): Rule.RuleListener {
+    const options = (context.options[0] || {}) as PreferEarlyReturnOptions;
+    const maxLines = options.maxLines !== undefined ? options.maxLines : 3;
+
+    function getFunctionBody(node: any): any[] {
+      if (node.body?.type === 'BlockStatement') return node.body.body;
+      return [];
+    }
+
+    function isOnlyStatement(fnNode: any, ifNode: any): boolean {
+      const body = getFunctionBody(fnNode);
+      return body.length === 1 && body[0] === ifNode;
+    }
+
+    function bodyLineCount(ifNode: any): number {
+      const body = ifNode.consequent;
+      if (!body?.loc) return 0;
+      if (body.type === 'BlockStatement') {
+        // Exclude the opening { and closing } lines
+        return Math.max(0, body.loc.end.line - body.loc.start.line - 1);
+      }
+      return body.loc.end.line - body.loc.start.line + 1;
+    }
+
+    function checkFunction(node: any): void {
+      const body = getFunctionBody(node);
+      if (body.length === 0) return;
+
+      // Find a leading if-statement that wraps the rest of the function body
+      // Pattern: first statement is an `if` with no `else`, and it contains
+      // the majority of the function (or is the only statement).
+      const firstStatement = body[0];
+      if (firstStatement?.type !== 'IfStatement') return;
+      if (firstStatement.alternate) return; // if/else — not the pattern
+
+      const wrapsAll = isOnlyStatement(node, firstStatement);
+      if (!wrapsAll) return;
+
+      if (bodyLineCount(firstStatement) < maxLines) return;
+
+      context.report({
+        node: firstStatement,
+        messageId: 'preferEarlyReturn'
+      });
+    }
+
+    return {
+      FunctionDeclaration: checkFunction,
+      FunctionExpression: checkFunction,
+      ArrowFunctionExpression: checkFunction
+    };
+  }
+};
+
+export default rule;

--- a/tests/max-function-length.test.ts
+++ b/tests/max-function-length.test.ts
@@ -1,0 +1,144 @@
+import { ruleTester } from './config';
+import rule from '../rules/max-function-length';
+
+// Helper to generate a function body with N non-blank lines
+function makeLines(n: number): string {
+  return Array.from({ length: n }, (_, i) => `  const x${i} = ${i};`).join('\n');
+}
+
+ruleTester.run('max-function-length', rule, {
+  valid: [
+    // Short function — under default limit
+    `function short() {
+      const a = 1;
+      const b = 2;
+      return a + b;
+    }`,
+
+    // Exactly at the limit with custom maxLines
+    {
+      code: `function atLimit() {
+        const a = 1;
+        const b = 2;
+        return a + b;
+      }`,
+      options: [{ maxLines: 4 }]
+    },
+
+    // Arrow function — under limit
+    `const fn = () => {
+      return 1;
+    };`,
+
+    // Blank lines don't count by default
+    {
+      code: `function withBlanks() {
+        const a = 1;
+
+        const b = 2;
+
+        return a + b;
+      }`,
+      options: [{ maxLines: 3 }]
+    },
+
+    // Comment lines don't count by default
+    {
+      code: `function withComments() {
+        // this is a comment
+        const a = 1;
+        /* block comment */
+        return a;
+      }`,
+      options: [{ maxLines: 2 }]
+    },
+
+    // Anonymous function expression — under limit
+    `const obj = {
+      method: function() {
+        return 1;
+      }
+    };`,
+  ],
+
+  invalid: [
+    // Exceeds default limit of 30
+    {
+      code: `function toolong() {\n${makeLines(31)}\n}`,
+      errors: [{ messageId: 'maxFunctionLength' }]
+    },
+
+    // Named function exceeds custom limit
+    {
+      code: `function tooLong() {
+        const a = 1;
+        const b = 2;
+        const c = 3;
+        const d = 4;
+        return a + b + c + d;
+      }`,
+      options: [{ maxLines: 4 }],
+      errors: [{ messageId: 'maxFunctionLength', data: { name: 'tooLong', lines: '5', maxLines: '4' } }]
+    },
+
+    // Arrow function assigned to variable — name inferred
+    {
+      code: `const processData = () => {
+        const a = 1;
+        const b = 2;
+        const c = 3;
+        return a + b + c;
+      };`,
+      options: [{ maxLines: 3 }],
+      errors: [{ messageId: 'maxFunctionLength', data: { name: 'processData', lines: '4', maxLines: '3' } }]
+    },
+
+    // Method in object literal — name inferred
+    {
+      code: `const obj = {
+        handleClick: function() {
+          const a = 1;
+          const b = 2;
+          const c = 3;
+          return a + b + c;
+        }
+      };`,
+      options: [{ maxLines: 3 }],
+      errors: [{ messageId: 'maxFunctionLength', data: { name: 'handleClick', lines: '4', maxLines: '3' } }]
+    },
+
+    // Blank lines count when skipBlankLines is false
+    {
+      code: `function withBlanks() {
+        const a = 1;
+
+        const b = 2;
+
+        return a + b;
+      }`,
+      options: [{ maxLines: 4, skipBlankLines: false }],
+      errors: [{ messageId: 'maxFunctionLength' }]
+    },
+
+    // Two functions — each flagged independently
+    {
+      code: `function a() {
+        const x = 1;
+        const y = 2;
+        const z = 3;
+        return x + y + z;
+      }
+      function b() {
+        const p = 1;
+        const q = 2;
+        const r = 3;
+        return p + q + r;
+      }`,
+      options: [{ maxLines: 3 }],
+      errors: [
+        { messageId: 'maxFunctionLength', data: { name: 'a', lines: '4', maxLines: '3' } },
+        { messageId: 'maxFunctionLength', data: { name: 'b', lines: '4', maxLines: '3' } }
+      ]
+    }
+  ]
+});

--- a/tests/prefer-early-return.test.ts
+++ b/tests/prefer-early-return.test.ts
@@ -1,0 +1,118 @@
+import { ruleTester } from './config';
+import rule from '../rules/prefer-early-return';
+
+ruleTester.run('prefer-early-return', rule, {
+  valid: [
+    // Early return pattern — already correct
+    `function validate(user) {
+      if (!user) return;
+      processUser(user);
+      saveUser(user);
+      notifyUser(user);
+    }`,
+
+    // if/else — not the wrapping pattern
+    `function process(x) {
+      if (x > 0) {
+        doSomething(x);
+        doMore(x);
+        finish(x);
+        cleanup(x);
+      } else {
+        handleNegative(x);
+      }
+    }`,
+
+    // Only one line in the body — under default threshold of 3
+    `function check(x) {
+      if (x) {
+        doSomething(x);
+      }
+    }`,
+
+    // Two-line body — under threshold
+    `function check(x) {
+      if (x) {
+        doA(x);
+        doB(x);
+      }
+    }`,
+
+    // Multiple statements — not just an if
+    `function process(x) {
+      const y = transform(x);
+      if (y) {
+        doSomething(y);
+        doMore(y);
+        finish(y);
+        cleanup(y);
+      }
+    }`,
+
+    // Custom threshold — body just under it
+    {
+      code: `function fn(x) {
+        if (x) {
+          doA(x);
+          doB(x);
+          doC(x);
+        }
+      }`,
+      options: [{ maxLines: 4 }]
+    }
+  ],
+
+  invalid: [
+    // Classic wrap-everything-in-if
+    {
+      code: `function processUser(user) {
+        if (user) {
+          validateUser(user);
+          enrichUser(user);
+          saveUser(user);
+          notifyUser(user);
+        }
+      }`,
+      errors: [{ messageId: 'preferEarlyReturn' }]
+    },
+
+    // Arrow function
+    {
+      code: `const handleEvent = (event) => {
+        if (event.valid) {
+          logEvent(event);
+          processEvent(event);
+          dispatchEvent(event);
+          archiveEvent(event);
+        }
+      };`,
+      errors: [{ messageId: 'preferEarlyReturn' }]
+    },
+
+    // Function expression
+    {
+      code: `const fn = function(x) {
+        if (x !== null) {
+          step1(x);
+          step2(x);
+          step3(x);
+          step4(x);
+        }
+      };`,
+      errors: [{ messageId: 'preferEarlyReturn' }]
+    },
+
+    // Custom lower threshold
+    {
+      code: `function fn(x) {
+        if (x) {
+          doA(x);
+          doB(x);
+          doC(x);
+        }
+      }`,
+      options: [{ maxLines: 2 }],
+      errors: [{ messageId: 'preferEarlyReturn' }]
+    }
+  ]
+});

--- a/types/rule-options.ts
+++ b/types/rule-options.ts
@@ -65,4 +65,14 @@ export interface HighFanOutOptions extends BaseRuleOptions {
   ignoreBuiltIns?: boolean;
   ignoreThisReferences?: boolean;
   minFunctionLength?: number;
+}
+
+export interface MaxFunctionLengthOptions extends BaseRuleOptions {
+  maxLines?: number;
+  skipBlankLines?: boolean;
+  skipComments?: boolean;
+}
+
+export interface PreferEarlyReturnOptions extends BaseRuleOptions {
+  maxLines?: number;
 } 


### PR DESCRIPTION
## Summary

- **`max-function-length`**: Flags functions whose body exceeds a configurable line limit (default: 30). Skips blank lines and comments by default. Complements `low-function-cohesion` — cohesion catches unrelated blocks, length catches bloated-but-related functions.
- **`prefer-early-return`**: Detects functions where the entire body is wrapped in a single `if` (no `else`) and suggests inverting the condition to return early. Reduces nesting and pairs naturally with `max-nesting-depth`.

## Options

**`max-function-length`**
- `maxLines` (default: 30) — maximum body lines allowed
- `skipBlankLines` (default: true) — exclude blank lines from count
- `skipComments` (default: true) — exclude comment lines from count

**`prefer-early-return`**
- `maxLines` (default: 3) — minimum lines in the if-body to trigger the rule

## Test plan

- [x] 120/120 tests passing
- [x] Both rules registered in `index.ts` and `rules/index.ts`
- [x] Type options added to `types/rule-options.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)